### PR TITLE
Fix another naming of extension

### DIFF
--- a/src/main/java/com/qixalite/spongestart/SpongeStart.java
+++ b/src/main/java/com/qixalite/spongestart/SpongeStart.java
@@ -40,7 +40,7 @@ public class SpongeStart implements Plugin<Project>  {
 
         this.project.afterEvaluate(projectAfter -> {
             this.project.getConfigurations().maybeCreate(RUNTIME_SCOPE);
-            setupTasks((SpongeStartExtension) projectAfter.getExtensions().getByName("sponge"));
+            setupTasks((SpongeStartExtension) projectAfter.getExtensions().getByName("spongestart"));
         });
     }
 


### PR DESCRIPTION
Fixed a `ClassCastException` when spongestart is used with sponge plugin. Did not find it out until looking into the stacktrace in bash. Ref #4.